### PR TITLE
fix: SmartSearch 404 error - use correct backend API URL in production

### DIFF
--- a/apps/web/src/app/(authenticated)/search-insights/page.tsx
+++ b/apps/web/src/app/(authenticated)/search-insights/page.tsx
@@ -4,11 +4,16 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { BarChart3, TrendingUp, Clock, Search, MessageCircle } from 'lucide-react';
 
+// Environment-based API configuration
+const API_BASE_URL = process.env.NODE_ENV === 'production' 
+  ? 'https://all-in-one-career-api.onrender.com'
+  : 'http://localhost:4000';
+
 interface SearchInsights {
   totalSearches: number;
   topKeywords: Array<{ keyword: string; count: number }>;
   longestQueries: Array<{ query: string; length: number }>;
-  recentQueries: Array<{ query: string; answer?: string; createdAt: Date }>;
+  recentQueries: Array<{ query: string; answer?: string | null; createdAt: Date }>;
 }
 
 export default function SearchInsightsPage() {
@@ -26,7 +31,7 @@ export default function SearchInsightsPage() {
       setLoading(true);
       setError(null);
       
-      const response = await fetch('/api/search-insights', {
+      const response = await fetch(`${API_BASE_URL}/api/search-insights`, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/apps/web/src/components/SmartSearch.tsx
+++ b/apps/web/src/components/SmartSearch.tsx
@@ -4,8 +4,13 @@ import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search, FileText, Briefcase, Mail, Users, Building, Calendar, Filter, X, MessageCircle } from 'lucide-react';
 
+// Environment-based API configuration
+const API_BASE_URL = process.env.NODE_ENV === 'production' 
+  ? 'https://all-in-one-career-api.onrender.com'
+  : 'http://localhost:4000';
+
 interface SearchResult {
-  type: 'Application' | 'ATS' | 'Portfolio' | 'Email' | 'Referral' | 'Task' | 'Job Description';
+  type: 'Application' | 'Portfolio' | 'Referral' | 'Job Description';
   title: string;
   subInfo: string;
   id: string;
@@ -106,7 +111,7 @@ export default function SmartSearch() {
       }
       
       console.log(`Searching for: "${searchQuery}" with filters:`, filters);
-      const response = await fetch(`/api/search?${params.toString()}`);
+      const response = await fetch(`${API_BASE_URL}/api/search?${params.toString()}`);
       
       if (!response.ok) {
         const errorData = await response.text();
@@ -134,7 +139,7 @@ export default function SmartSearch() {
     setResults([]);
     
     try {
-      const response = await fetch('/api/ask', {
+      const response = await fetch(`${API_BASE_URL}/api/ask`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
- Added environment-based API configuration
- Production: https://all-in-one-career-api.onrender.com
- Development: http://localhost:4000
- Updated SmartSearch component and search-insights page
- Fixed frontend calling wrong domain in production
- Backend routing confirmed correct (/api/search endpoint exists)