### PR TITLE
feat: Hide Profile and Logout options in collapsed sidebar menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -160,7 +160,9 @@ export default function Sidebar({ isCollapsed, onToggle }: SidebarProps) {
               </h3>
             )}
             <ul className="space-y-2">
-              {generalItems.map((item) => (
+              {generalItems
+                .filter(item => !isCollapsed || item.label === 'Settings' || item.label === 'Help') // Hide Profile and Logout when collapsed
+                .map((item) => (
                 <li key={item.href}>
                   <button
                     onClick={item.action}


### PR DESCRIPTION
- Removed Profile and Logout items from collapsed sidebar view
- Only Settings and Help remain visible when sidebar is collapsed
- Profile and Logout are still accessible from Topbar user dropdown
- Maintains clean, minimal collapsed sidebar appearance
- Full functionality preserved when sidebar is expanded