### PR TITLE
fix: CRITICAL - Firebase Admin import syntax for ES modules - Fix imp…

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { auth } from 'firebase-admin';
+import admin from 'firebase-admin';
 
 interface AuthenticatedRequest extends Request {
   user?: {
@@ -18,7 +18,7 @@ export const authenticateToken = async (req: AuthenticatedRequest, res: Response
 
   try {
     // Verify Firebase ID token
-    const decodedToken = await auth().verifyIdToken(token);
+    const decodedToken = await admin.auth().verifyIdToken(token);
     req.user = {
       uid: decodedToken.uid,
       email: decodedToken.email || ''
@@ -37,7 +37,7 @@ export const optionalAuth = async (req: AuthenticatedRequest, res: Response, nex
   if (token) {
     try {
       // Verify Firebase ID token
-      const decodedToken = await auth().verifyIdToken(token);
+      const decodedToken = await admin.auth().verifyIdToken(token);
       req.user = {
         uid: decodedToken.uid,
         email: decodedToken.email || ''

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import jwt from 'jsonwebtoken';
-import { getAuth } from 'firebase-admin/auth';
+import admin from 'firebase-admin';
 
 export default function authRouter(): Router {
   const r = Router();
@@ -15,7 +15,7 @@ export default function authRouter(): Router {
       }
 
       // Verify Firebase token
-      const decodedToken = await getAuth().verifyIdToken(firebaseToken);
+      const decodedToken = await admin.auth().verifyIdToken(firebaseToken);
       
       if (decodedToken.email !== email) {
         return res.status(401).json({ error: 'Email mismatch' });


### PR DESCRIPTION
…ort { auth } from 'firebase-admin' to import admin from 'firebase-admin' - Update all Firebase Admin imports to use correct ES modules syntax - Fix auth middleware and auth routes for proper Firebase token verification - Resolves Render deployment failure with SyntaxError