### PR TITLE
feat(notifications-prefs): Phase 2 - notification preferences model, …

### DIFF
--- a/apps/api/src/utils/seedNotifications.ts
+++ b/apps/api/src/utils/seedNotifications.ts
@@ -1,40 +1,40 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, NotificationType } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-export async function seedTestNotifications(userId: string) {
+export async function seedTestNotifications(userId: string, onlyType?: 'SYSTEM' | 'TASK' | 'FEATURE' | 'MESSAGE') {
   const notifications = [
     {
       userId,
-      type: 'SYSTEM' as const,
+      type: 'SYSTEM' as NotificationType,
       title: 'Welcome to Climbly.ai!',
       message: 'Your account has been successfully created. Start by uploading your resume for ATS scanning.',
       isRead: false,
     },
     {
       userId,
-      type: 'FEATURE' as const,
+      type: 'FEATURE' as NotificationType,
       title: 'New AI Search Feature',
       message: 'You can now ask questions like "What was my highest ATS score?" in the search bar.',
       isRead: false,
     },
     {
       userId,
-      type: 'TASK' as const,
+      type: 'TASK' as NotificationType,
       title: 'Resume Analysis Complete',
       message: 'Your resume has been analyzed for the Software Engineer position at Google. Score: 92%',
       isRead: true,
     },
     {
       userId,
-      type: 'MESSAGE' as const,
+      type: 'MESSAGE' as NotificationType,
       title: 'New Referral Request',
       message: 'John from Microsoft has responded to your referral request for the Frontend Developer role.',
       isRead: false,
     },
     {
       userId,
-      type: 'SYSTEM' as const,
+      type: 'SYSTEM' as NotificationType,
       title: 'Weekly Summary Ready',
       message: 'Your weekly job application summary is ready. You applied to 5 positions this week.',
       isRead: true,
@@ -45,6 +45,7 @@ export async function seedTestNotifications(userId: string) {
     console.log(`Creating ${notifications.length} test notifications for user: ${userId}`);
     
     for (const notification of notifications) {
+      if (onlyType && notification.type !== onlyType) continue;
       await prisma.notification.create({
         data: notification,
       });

--- a/apps/web/src/app/(authenticated)/settings/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/notifications/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useSWR from 'swr';
+import { useAuth } from '@/contexts/AuthContext';
+
+const API_URL = process.env.NODE_ENV === 'production'
+  ? 'https://all-in-one-career-api.onrender.com'
+  : 'http://localhost:4000';
+
+type PreferenceType = 'system' | 'task' | 'promotion' | 'activity';
+
+interface PreferenceItem { type: PreferenceType; enabled: boolean }
+
+const fetcher = async (url: string, token: string | null) => {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API_URL}${url}`, { headers });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+};
+
+export default function NotificationPreferencesPage() {
+  const { getAuthToken, isGuest } = useAuth();
+  const token = getAuthToken();
+  const shouldFetch = !isGuest && token;
+
+  const { data, mutate, isLoading } = useSWR<{ preferences: PreferenceItem[] }>(
+    shouldFetch ? ['/api/notifications/preferences', token] : null,
+    ([url, t]: [string, string | null]) => fetcher(url, t)
+  );
+
+  const [localPrefs, setLocalPrefs] = useState<PreferenceItem[]>([
+    { type: 'system', enabled: true },
+    { type: 'task', enabled: true },
+    { type: 'promotion', enabled: true },
+    { type: 'activity', enabled: true },
+  ]);
+
+  useEffect(() => {
+    if (data?.preferences) setLocalPrefs(data.preferences);
+  }, [data]);
+
+  const togglePref = async (type: PreferenceType, enabled: boolean) => {
+    if (!token) return;
+    setLocalPrefs(prev => prev.map(p => p.type === type ? { ...p, enabled } : p));
+    try {
+      const headers: HeadersInit = { 'Content-Type': 'application/json' };
+      headers.Authorization = `Bearer ${token}`;
+      await fetch(`${API_URL}/api/notifications/preferences/update`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ type, enabled })
+      });
+      mutate();
+    } catch (e) {
+      console.error('Failed to update preference', e);
+    }
+  };
+
+  const rows = [
+    { type: 'system', label: 'System Alerts', desc: 'Announcements, maintenance, and important updates.' },
+    { type: 'task', label: 'Task Updates', desc: 'Resume scans, application statuses, and reminders.' },
+    { type: 'promotion', label: 'Promotional Updates', desc: 'New features, offers, and newsletters.' },
+    { type: 'activity', label: 'Activity / Misc.', desc: 'General activity and informational messages.' },
+  ] as const;
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-8">
+      <h1 className="text-xl font-semibold text-gray-900">Notification Preferences</h1>
+      <p className="text-sm text-gray-500 mt-1">Choose which notifications you want to receive.</p>
+
+      <div className="mt-6 bg-white border border-gray-200 rounded-xl divide-y divide-gray-100">
+        {rows.map(row => {
+          const current = localPrefs.find(p => p.type === row.type) || { enabled: true };
+          return (
+            <div key={row.type} className="flex items-center justify-between px-4 py-4">
+              <div>
+                <div className="text-sm font-medium text-gray-900">{row.label}</div>
+                <div className="text-xs text-gray-500 mt-0.5">{row.desc}</div>
+              </div>
+              <label className="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={current ? current.enabled : true}
+                  onChange={(e) => togglePref(row.type, e.target.checked)}
+                />
+                <div className="w-10 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-4 rtl:peer-checked:after:-translate-x-full after:content-[''] after:absolute relative after:top-[3px] after:left-[3px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#0E8F6B]"></div>
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+

--- a/apps/web/src/components/notifications/NotificationBell.tsx
+++ b/apps/web/src/components/notifications/NotificationBell.tsx
@@ -42,6 +42,7 @@ const formatTimeAgo = (dateString: string) => {
 
 export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
+  const [activeFilter, setActiveFilter] = useState<'ALL' | 'SYSTEM' | 'TASK' | 'FEATURE' | 'MESSAGE'>('ALL');
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { notifications, unreadCount, isLoading, markAllAsRead, markAsRead } = useNotifications();
 
@@ -116,6 +117,29 @@ export default function NotificationBell() {
             )}
           </div>
 
+          {/* Category Filter Chips */}
+          <div className="px-3 pt-2 pb-1 border-b border-gray-100 flex flex-wrap gap-2">
+            {([
+              { key: 'ALL', label: 'All' },
+              { key: 'SYSTEM', label: 'System' },
+              { key: 'TASK', label: 'Task' },
+              { key: 'FEATURE', label: 'Promotion' },
+              { key: 'MESSAGE', label: 'Activity' },
+            ] as const).map((chip) => (
+              <button
+                key={chip.key}
+                onClick={() => setActiveFilter(chip.key)}
+                className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                  activeFilter === chip.key
+                    ? 'bg-[#0E8F6B] text-white border-[#0E8F6B]'
+                    : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                {chip.label}
+              </button>
+            ))}
+          </div>
+
           {/* Content */}
           <div className="max-h-80 overflow-y-auto">
             {isLoading ? (
@@ -130,7 +154,10 @@ export default function NotificationBell() {
               </div>
             ) : (
               <div className="py-1">
-                {notifications.map((notification) => (
+                {(activeFilter === 'ALL' 
+                  ? notifications 
+                  : notifications.filter(n => n.type === activeFilter)
+                ).map((notification) => (
                   <div
                     key={notification.id}
                     onClick={() => handleNotificationClick(notification)}

--- a/prisma/migrations/20250818160539_add_notification_preferences/migration.sql
+++ b/prisma/migrations/20250818160539_add_notification_preferences/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "public"."NotificationPreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationPreference_userId_type_key" ON "public"."NotificationPreference"("userId", "type");
+
+-- AddForeignKey
+ALTER TABLE "public"."NotificationPreference" ADD CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
   logs             Log[]
   searchHistory    SearchHistory[]
   notifications    Notification[]
+  notificationPreferences NotificationPreference[]
 }
 
 model JobDescription {
@@ -141,4 +142,17 @@ enum NotificationType {
   TASK
   SYSTEM
   FEATURE
+}
+
+model NotificationPreference {
+  id        String   @id @default(uuid())
+  userId    String
+  type      String
+  enabled   Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, type])
 }


### PR DESCRIPTION
…endpoints, settings UI, and bell category filters\n\n- DB: NotificationPreference model + migration\n- API: GET/POST preferences; notifications respect enabled types; seed-test supports ?type=\n- Web: Settings page with toggles; bell dropdown chips (All/System/Task/Promotion/Activity)