### PR TITLE
fix(backend): Convert require() to ES module import for HTTP server c…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,7 +26,8 @@ const logger = pino({ transport: { target: 'pino-pretty' } });
 const prisma = new PrismaClient();
 
 // Create HTTP server for WebSocket integration
-const server = require('http').createServer(app);
+import { createServer } from 'http';
+const server = createServer(app);
 
 initFirebase();
 


### PR DESCRIPTION
…reation\n\n- Fixed deployment error: 'require is not defined in ES module scope'\n- Changed require('http').createServer to import { createServer } from 'http'\n- Backend should now deploy successfully on Render