### PR TITLE
feat(notifications): Disable browser push notifications, keep only in…

### DIFF
--- a/apps/web/src/components/notifications/NotificationBell.tsx
+++ b/apps/web/src/components/notifications/NotificationBell.tsx
@@ -48,7 +48,7 @@ export default function NotificationBell() {
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { notifications, unreadCount, isLoading, markAllAsRead, markAsRead, showArchived, setShowArchived, refresh } = useNotifications();
-  const { connectionStatus, browserNotificationPermission, requestNotificationPermission } = useRealtimeNotifications();
+  const { connectionStatus } = useRealtimeNotifications();
   const { getAuthToken } = useAuth();
   const token = getAuthToken();
   const API_URL = process.env.NODE_ENV === 'production' ? 'https://all-in-one-career-api.onrender.com' : 'http://localhost:4000';
@@ -87,12 +87,7 @@ export default function NotificationBell() {
     }
   };
 
-  const handleBellClick = async () => {
-    // Request notification permission on first click if not granted
-    if (browserNotificationPermission === 'default') {
-      await requestNotificationPermission();
-    }
-    
+  const handleBellClick = () => {
     setIsOpen(!isOpen);
   };
 


### PR DESCRIPTION
…-app notifications\n\n- Removed all browser notification permission requests (Notification.requestPermission)\n- Removed browser notification display logic (new Notification())\n- Removed service worker registration and push notification code\n- Kept WebSocket real-time updates for in-app notifications\n- Maintained in-app badge counter and dropdown functionality\n- Preserved user notification preferences and filtering\n- Ensured no browser permission prompts appear on bell click or page load\n- Cleaned up unused imports and variables\n- Build successful with no browser notification dependencies