### PR TITLE
feat: add archive/restore functionality to notification system

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -119,5 +119,66 @@ export function notificationsRouter(prisma: PrismaClient): Router {
     }
   });
 
+  // POST /api/notifications/:id/archive - Archive a notification
+  router.post('/:id/archive', authenticateToken, async (req: any, res) => {
+    try {
+      const userId = req.user.uid;
+      const notificationId = req.params.id;
+
+      const notification = await prisma.notification.findFirst({
+        where: {
+          id: notificationId,
+          userId
+        }
+      });
+
+      if (!notification) {
+        return res.status(404).json({ error: 'Notification not found' });
+      }
+
+      await prisma.notification.update({
+        where: { id: notificationId },
+        data: { 
+          archived: true,
+          isRead: true // Mark as read when archiving
+        }
+      });
+
+      res.json({ success: true, message: 'Notification archived' });
+    } catch (error) {
+      console.error('Error archiving notification:', error);
+      res.status(500).json({ error: 'Failed to archive notification' });
+    }
+  });
+
+  // POST /api/notifications/:id/restore - Restore an archived notification
+  router.post('/:id/restore', authenticateToken, async (req: any, res) => {
+    try {
+      const userId = req.user.uid;
+      const notificationId = req.params.id;
+
+      const notification = await prisma.notification.findFirst({
+        where: {
+          id: notificationId,
+          userId
+        }
+      });
+
+      if (!notification) {
+        return res.status(404).json({ error: 'Notification not found' });
+      }
+
+      await prisma.notification.update({
+        where: { id: notificationId },
+        data: { archived: false }
+      });
+
+      res.json({ success: true, message: 'Notification restored' });
+    } catch (error) {
+      console.error('Error restoring notification:', error);
+      res.status(500).json({ error: 'Failed to restore notification' });
+    }
+  });
+
   return router;
 }

--- a/apps/web/src/components/notifications/ToastMessage.tsx
+++ b/apps/web/src/components/notifications/ToastMessage.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CheckCircle, XCircle, X } from 'lucide-react';
+
+interface ToastMessageProps {
+  message: string;
+  type: 'success' | 'error';
+  onClose: () => void;
+  duration?: number;
+}
+
+export default function ToastMessage({ 
+  message, 
+  type, 
+  onClose, 
+  duration = 3000 
+}: ToastMessageProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(false);
+      setTimeout(onClose, 300); // Wait for fade out animation
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const bgColor = type === 'success' 
+    ? 'bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-800' 
+    : 'bg-red-50 border-red-200 dark:bg-red-900/20 dark:border-red-800';
+  
+  const textColor = type === 'success' 
+    ? 'text-green-800 dark:text-green-200' 
+    : 'text-red-800 dark:text-red-200';
+  
+  const iconColor = type === 'success' 
+    ? 'text-green-500 dark:text-green-400' 
+    : 'text-red-500 dark:text-red-400';
+
+  return (
+    <div className={`
+      fixed top-4 right-4 z-50 max-w-sm w-full bg-white dark:bg-gray-800 
+      border rounded-lg shadow-lg transition-all duration-300 ease-in-out
+      ${bgColor}
+      ${isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
+    `}>
+      <div className="flex items-start p-4">
+        <div className="flex-shrink-0">
+          {type === 'success' ? (
+            <CheckCircle className={`w-5 h-5 ${iconColor}`} />
+          ) : (
+            <XCircle className={`w-5 h-5 ${iconColor}`} />
+          )}
+        </div>
+        <div className="ml-3 flex-1">
+          <p className={`text-sm font-medium ${textColor}`}>
+            {message}
+          </p>
+        </div>
+        <div className="ml-4 flex-shrink-0">
+          <button
+            onClick={handleClose}
+            className={`inline-flex rounded-md p-1.5 ${textColor} hover:bg-white/50 dark:hover:bg-gray-700/50 transition-colors`}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -113,6 +113,60 @@ export function useNotifications() {
     }
   };
 
+  const archiveNotification = async (notificationId: string) => {
+    if (!user) return;
+
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/archive`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        // Refetch notifications to update the UI
+        mutate();
+        return { success: true, message: 'Notification archived' };
+      } else {
+        const errorData = await response.json();
+        return { success: false, message: errorData.error || 'Failed to archive notification' };
+      }
+    } catch (error) {
+      console.error('Error archiving notification:', error);
+      return { success: false, message: 'Failed to archive notification' };
+    }
+  };
+
+  const restoreNotification = async (notificationId: string) => {
+    if (!user) return;
+
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/restore`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        // Refetch notifications to update the UI
+        mutate();
+        return { success: true, message: 'Notification restored' };
+      } else {
+        const errorData = await response.json();
+        return { success: false, message: errorData.error || 'Failed to restore notification' };
+      }
+    } catch (error) {
+      console.error('Error restoring notification:', error);
+      return { success: false, message: 'Failed to restore notification' };
+    }
+  };
+
   const unreadCount = notifications?.filter(n => !n.isRead && !n.archived).length || 0;
 
   // Filter notifications based on selected filter
@@ -137,6 +191,8 @@ export function useNotifications() {
     error,
     markAsRead,
     markAllAsRead,
+    archiveNotification,
+    restoreNotification,
     mutate,
     getFilteredNotifications,
   };


### PR DESCRIPTION
- Add backend endpoints: POST /api/notifications/:id/archive and POST /api/notifications/:id/restore
- Implement three-dot kebab menu (⋮) for each notification item
- Add archive/restore actions with proper API integration
- Show 'Archive' for unread/all notifications, 'Restore' for archived ones
- Auto-mark notifications as read when archiving
- Add toast messages for success/error feedback
- Immediately refresh notification list after archive/restore operations
- Support proper filtering between Unread/All/Archived tabs