### PR TITLE
fix: add notification archive functionality with proper UI refresh

### DIFF
--- a/apps/web/src/hooks/useNotifications.ts
+++ b/apps/web/src/hooks/useNotifications.ts
@@ -122,6 +122,31 @@ export function useNotifications() {
     }
   };
 
+  const archiveNotification = async (notificationId: string) => {
+    if (!user) return;
+
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}/archive`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        // Refetch notifications to update the UI
+        mutate();
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error('Error archiving notification:', error);
+      return false;
+    }
+  };
+
   const unreadCount = notifications?.filter(n => !n.isRead && !n.archived).length || 0;
 
   const setOnNewNotification = (callback: ((notification: Notification) => void) | null) => {
@@ -135,6 +160,7 @@ export function useNotifications() {
     error,
     markAsRead,
     markAllAsRead,
+    archiveNotification,
     mutate,
     setOnNewNotification,
   };


### PR DESCRIPTION
- Add archiveNotification function to useNotifications hook
- Add three-dot menu (MoreVertical) to each notification card
- Implement archive option in dropdown menu with Archive icon
- Call backend API /api/notifications/:id/archive endpoint
- Automatically refresh UI using mutate() after successful archive
- Show success/error toast feedback for user
- Close menu after archive action
- Ensure proper click outside handling for menu
- Archive functionality now properly moves notifications between tabs