### PR TITLE
feat: add missing notification archive endpoints to backend API

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -119,5 +119,66 @@ export function notificationsRouter(prisma: PrismaClient): Router {
     }
   });
 
+  // POST /api/notifications/:id/archive - Archive a notification
+  router.post('/:id/archive', authenticateToken, async (req: any, res) => {
+    try {
+      const userId = req.user.uid;
+      const notificationId = req.params.id;
+
+      const notification = await prisma.notification.findFirst({
+        where: {
+          id: notificationId,
+          userId
+        }
+      });
+
+      if (!notification) {
+        return res.status(404).json({ error: 'Notification not found' });
+      }
+
+      await prisma.notification.update({
+        where: { id: notificationId },
+        data: { 
+          archived: true,
+          isRead: true // Mark as read when archiving
+        }
+      });
+
+      res.json({ success: true, message: 'Notification archived' });
+    } catch (error) {
+      console.error('Error archiving notification:', error);
+      res.status(500).json({ error: 'Failed to archive notification' });
+    }
+  });
+
+  // POST /api/notifications/:id/restore - Restore an archived notification
+  router.post('/:id/restore', authenticateToken, async (req: any, res) => {
+    try {
+      const userId = req.user.uid;
+      const notificationId = req.params.id;
+
+      const notification = await prisma.notification.findFirst({
+        where: {
+          id: notificationId,
+          userId
+        }
+      });
+
+      if (!notification) {
+        return res.status(404).json({ error: 'Notification not found' });
+      }
+
+      await prisma.notification.update({
+        where: { id: notificationId },
+        data: { archived: false }
+      });
+
+      res.json({ success: true, message: 'Notification restored' });
+    } catch (error) {
+      console.error('Error restoring notification:', error);
+      res.status(500).json({ error: 'Failed to restore notification' });
+    }
+  });
+
   return router;
 }


### PR DESCRIPTION
- Add POST /api/notifications/:id/archive endpoint for archiving notifications
- Add POST /api/notifications/:id/restore endpoint for restoring archived notifications
- Archive endpoint marks notification as archived=true and isRead=true
- Restore endpoint sets archived=false
- Both endpoints require authentication and validate user ownership
- Fixes 404 error when frontend tries to archive notifications