### PR TITLE
fix: resolve JSON import issue in textProcessor

### DIFF
--- a/apps/api/src/utils/textProcessor.ts
+++ b/apps/api/src/utils/textProcessor.ts
@@ -1,8 +1,8 @@
 import { removeStopwords } from 'stopword';
-import * as skillsData from '../data/skills.json';
+import skillsData from '../data/skills.json';
 
 // Load skills as a Set for faster lookups
-const SKILLS_SET = new Set((skillsData as string[]).map((skill: string) => skill.toLowerCase()));
+const SKILLS_SET = new Set(skillsData.map((skill: string) => skill.toLowerCase()));
 
 /**
  * Tokenize text into keywords


### PR DESCRIPTION
🔧 Problem: skillsData.map is not a function error in production The import * as skillsData was importing as a module object instead of array

✅ Solution: Changed to default import
- Changed from: import * as skillsData from '../data/skills.json'
- Changed to: import skillsData from '../data/skills.json'
- Removed unnecessary type casting since default import gives us the array directly

This should resolve the deployment crash and allow the API to start properly.