### PR TITLE
fix: Update pdf-parse version specification to match lockfile

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,7 +27,7 @@
     "mammoth": "^1.10.0",
     "multer": "^2.0.2",
     "node-fetch": "^3.3.2",
-    "pdf-parse": "1.1.1",
+    "pdf-parse": "^1.1.1",
     "pino": "^9.9.0",
     "pino-pretty": "^13.1.1",
     "stopword": "^3.1.5",


### PR DESCRIPTION
- Change pdf-parse from '1.1.1' to '^1.1.1' in package.json
- This resolves the Vercel deployment error about lockfile mismatch
- Ensures consistent version specification across the project