### PR TITLE
🔧 Fix Render deployment: Remove problematic pdf-parse package

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,7 +35,6 @@
     "mammoth": "^1.10.0",
     "multer": "^2.0.2",
     "node-fetch": "^3.3.2",
-    "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^5.4.54",
     "pino": "^9.9.0",
     "pino-pretty": "^13.1.1",
@@ -49,7 +48,6 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.3.0",
-    "@types/pdf-parse": "^1.1.5",
     "ts-node-dev": "^2.0.0",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2"

--- a/apps/api/src/routes/ats.ts
+++ b/apps/api/src/routes/ats.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { PrismaClient } from '@prisma/client';
 import formidable from 'formidable';
 import fs from 'fs';
-import pdf from 'pdf-parse';
+// import pdf from 'pdf-parse'; // Removed due to production issues
 import mammoth from 'mammoth';
 import * as cheerio from 'cheerio';
 import axios from 'axios';
@@ -26,7 +26,7 @@ export default function atsRouter(prisma: PrismaClient): Router {
         maxFileSize: 10 * 1024 * 1024, // 10MB limit
         filter: ({ mimetype }) => {
           return (
-            mimetype === 'application/pdf' ||
+            // mimetype === 'application/pdf' || // Temporarily disabled due to production issues
             mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
             mimetype === 'application/msword' ||
             mimetype === 'text/plain'
@@ -45,9 +45,9 @@ export default function atsRouter(prisma: PrismaClient): Router {
       
       // Extract text based on file type
       if (file.mimetype === 'application/pdf') {
-        const dataBuffer = fs.readFileSync(file.filepath);
-        const data = await pdf(dataBuffer);
-        extractedText = data.text;
+        // PDF processing temporarily disabled due to production issues
+        // Will implement with a more stable PDF parser in future update
+        extractedText = 'PDF upload is temporarily disabled. Please copy and paste your resume text or use DOC/DOCX format.';
       } else if (file.mimetype?.includes('wordprocessingml') || file.mimetype === 'application/msword') {
         const result = await mammoth.extractRawText({ path: file.filepath });
         extractedText = result.value;
@@ -110,13 +110,10 @@ export default function atsRouter(prisma: PrismaClient): Router {
         const fileId = extractGoogleDriveFileId(url);
         const downloadUrl = `https://drive.google.com/uc?export=download&id=${fileId}`;
         
-        const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
-        const data = await pdf(response.data);
-        
-        return res.status(200).json({
-          success: true,
-          content: data.text,
-          title: 'Google Drive Document'
+        // PDF processing from Google Drive temporarily disabled
+        return res.status(400).json({
+          success: false,
+          error: 'PDF processing from Google Drive is temporarily disabled. Please download the file and upload it directly, or use DOC/DOCX format.'
         });
       }
 

--- a/apps/web/src/app/(authenticated)/ats-scanner/page.tsx
+++ b/apps/web/src/app/(authenticated)/ats-scanner/page.tsx
@@ -284,7 +284,7 @@ const ATSScanner: React.FC = () => {
                         <input
                           type="file"
                           className="hidden"
-                          accept=".pdf,.doc,.docx,.txt"
+                          accept=".doc,.docx,.txt"
                           onChange={(e) => {
                             const file = e.target.files?.[0];
                             if (file) handleFileUpload(file, 'resume');
@@ -294,7 +294,7 @@ const ATSScanner: React.FC = () => {
                       <span className="text-gray-500"> or drag and drop</span>
                     </div>
                     <p className="text-sm text-gray-500 mt-2">
-                      PDF, DOC, DOCX, TXT files only (max 10MB)
+                      DOC, DOCX, TXT files only (max 10MB) - PDF temporarily disabled
                     </p>
                   </>
                 )}
@@ -401,7 +401,7 @@ const ATSScanner: React.FC = () => {
                         <input
                           type="file"
                           className="hidden"
-                          accept=".pdf,.doc,.docx,.txt"
+                          accept=".doc,.docx,.txt"
                           onChange={(e) => {
                             const file = e.target.files?.[0];
                             if (file) handleFileUpload(file, 'job');
@@ -411,7 +411,7 @@ const ATSScanner: React.FC = () => {
                       <span className="text-gray-500"> or drag and drop</span>
                     </div>
                     <p className="text-sm text-gray-500 mt-2">
-                      PDF, DOC, DOCX, TXT files only (max 10MB)
+                      DOC, DOCX, TXT files only (max 10MB) - PDF temporarily disabled
                     </p>
                   </>
                 )}
@@ -493,7 +493,7 @@ const ATSScanner: React.FC = () => {
             <div>
               <h3 className="text-lg font-medium text-blue-900 mb-2">For best results:</h3>
               <ul className="text-blue-800 space-y-1 text-sm">
-                <li>• Upload your resume in PDF, DOC, or DOCX format</li>
+                <li>• Upload your resume in DOC or DOCX format (PDF temporarily disabled)</li>
                 <li>• Include the complete job description you're applying for</li>
                 <li>• Ensure your resume includes contact information and skills</li>
                 <li>• Use standard section headers (Experience, Education, Skills)</li>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
-      pdf-parse:
-        specifier: ^1.1.1
-        version: 1.1.1
       pdfjs-dist:
         specifier: ^5.4.54
         version: 5.4.54
@@ -121,9 +118,6 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
-      '@types/pdf-parse':
-        specifier: ^1.1.5
-        version: 1.1.5
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.3.0)(typescript@5.9.2)
@@ -1671,9 +1665,6 @@ packages:
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
-
-  '@types/pdf-parse@1.1.5':
-    resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -3350,9 +3341,6 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
-  node-ensure@0.0.0:
-    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -3495,10 +3483,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pdf-parse@1.1.1:
-    resolution: {integrity: sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==}
-    engines: {node: '>=6.8.1'}
 
   pdfjs-dist@5.4.54:
     resolution: {integrity: sha512-TBAiTfQw89gU/Z4LW98Vahzd2/LoCFprVGvGbTgFt+QCB1F+woyOPmNNVgLa6djX9Z9GGTnj7qE1UzpOVJiINw==}
@@ -6170,10 +6154,6 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
-  '@types/pdf-parse@1.1.5':
-    dependencies:
-      '@types/node': 24.3.0
-
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -8181,8 +8161,6 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-ensure@0.0.0: {}
-
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
@@ -8325,13 +8303,6 @@ snapshots:
   path-to-regexp@8.2.0: {}
 
   pathe@2.0.3: {}
-
-  pdf-parse@1.1.1:
-    dependencies:
-      debug: 3.2.7
-      node-ensure: 0.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   pdfjs-dist@5.4.54:
     optionalDependencies:


### PR DESCRIPTION
🚨 CRITICAL FIX for Render deployment issue:

✅ Problem Solved:
- Removed pdf-parse package that was causing ENOENT errors in production
- The package was trying to access test files that don't exist in Docker containers
- Error: ENOENT: no such file or directory, open './test/data/05-versions-space.pdf'

🔄 Changes Made:
- Removed pdf-parse and @types/pdf-parse dependencies
- Temporarily disabled PDF file upload functionality
- Updated file filters to accept only DOC, DOCX, TXT formats
- Added user-friendly messages about PDF being temporarily disabled
- Updated frontend file acceptance and help text

📋 Current File Support:
✅ DOC/DOCX files (via mammoth) - Working
✅ TXT files (direct read) - Working
⏸️ PDF files - Temporarily disabled until stable alternative found

🔮 Future Enhancement:
- Will implement a more production-stable PDF parser
- Options: pdfjs-dist, pdf-lib, or custom solution
- For now, users can copy/paste text or use DOC/DOCX format

This ensures the ATS Scanner deploys successfully on Render while maintaining core functionality.